### PR TITLE
(chore): Fix errors when using project out-of-tree

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,8 @@ if (CAN_TARGET STREQUAL "pico")
     # Pull in pico sdk (must be before project() call)
     include(src/rp2040/pico-sdk.cmake)
     
+    set(PICO_CXX_ENABLE_RTTI True)
+    
     add_compile_definitions(BOOST_SYSTEM_DISABLE_THREADS)
 
 elseif (IS_TEST_FUZZ_ENV STREQUAL "true")

--- a/src/rp2040/mcp2515/pico-mcp2515.cmake
+++ b/src/rp2040/mcp2515/pico-mcp2515.cmake
@@ -1,6 +1,6 @@
 set(PROJECT can_rp2040_mcp2515_lib_mcp2515)
 
-set(MCP2515_LIB_DIR ${CMAKE_SOURCE_DIR}/lib/rp2040/pico-mcp2515)
+set(MCP2515_LIB_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../../lib/rp2040/pico-mcp2515)
 
 project(
     ${PROJECT}

--- a/src/rp2040/pico-sdk.cmake
+++ b/src/rp2040/pico-sdk.cmake
@@ -1,3 +1,6 @@
-set(PICO_SDK_PATH ${CMAKE_SOURCE_DIR}/lib/rp2040/pico-sdk)
-
-include(${PICO_SDK_PATH}/external/pico_sdk_import.cmake)
+if(NOT DEFINED PICO_SDK_PATH)
+    set(PICO_SDK_PATH ${CMAKE_CURRENT_SOURCE_DIR}/lib/rp2040/pico-sdk)
+    include(${PICO_SDK_PATH}/external/pico_sdk_import.cmake)
+else()
+    message("Not importing pico-sdk as it appears to already be present.")
+endif()


### PR DESCRIPTION
- Enable RTTI for rp2040
- Use `CURRENT_SOURCE_DIR` so that imports resolve when out of tree
- Don't attempt to add pico-sdk if it is already present